### PR TITLE
Updated mongodb role to work with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 install:
   # install ansible
-  - pip install ansible
+  - sudo pip install ansible
 
   # configure ansible
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,7 @@ script:
 
   # check idempotence
   - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"
+    
+  # check that mongodb is running
+  - "curl localhost:27017"
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,10 @@ script:
 
   # check idempotence
   - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"
-    
+  
+  # start mongodb  
+  - sudo service mongod start
+
   # check that mongodb is running
   - "curl localhost:27017"
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+---
+sudo: required
+dist: trusty
+language: generic
+
+env:
+  - PLAYBOOK=test.yml
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  # install ansible
+  - pip install ansible
+
+  # configure ansible
+  - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+
+  # install dependencies from meta/main.yml
+  - "read dependencies < <(cat meta/main.yml  | grep 'role:' | awk '{print $3}' | tr '\n' ' '); ansible-galaxy install $dependencies"
+
+script:
+  # check syntax
+  - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --syntax-check"
+
+  # initial run
+  - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"
+
+  # check idempotence
+  - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,8 @@ script:
   # check idempotence
   - "ansible-playbook -i tests/inventory tests/$PLAYBOOK --connection=local --sudo"
   
-  # start mongodb  
-  - sudo service mongod start
-
-  # check that mongodb is running
-  - "curl localhost:27017"
-  
+  # check mongodb starts
+  - > 
+    sudo service mongod start | grep -q 'mongod start/running'
+    && (echo 'MongoDB is installed' && exit 0)
+    || (echo 'MongoDB is not installed' && exit 1)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [MongoDB](https://www.mongodb.org/) - document-oriented database
 
+[![Build Status](https://travis-ci.org/telusdigital/ansible-mongodb.svg?branch=master)](https://travis-ci.org/telusdigital/ansible-mongodb)
 [![Platforms](http://img.shields.io/badge/platforms-ubuntu-lightgrey.svg?style=flat)](#)
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Description
 Tunables
 --------
 * `mongodb_user` (string) - User to run MongoDB as?
+* `mongodb_group` (string) - Group to run MongoDB as?
 * `mongodb_runtime_root` (string) - Directory for runtime data
 * `mongodb_pidfile_path` (string) - Path for pidfile
 * `mongodb_log_root` (string) - Directory for logs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 mongodb_user: mongodb
+mongodb_group: mongodb
 
 mongodb_runtime_root: "{{ runtime_root | default('/var/run') }}/mongod"
 mongodb_pidfile_path: "{{ mongodb_runtime_root }}/mongod.pid"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,5 +16,5 @@
 
 - name: service | mongodb | reloaded
   service:
-    state: reloaded
     name: mongod
+    state: reloaded

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,20 @@
 ---
-- name: Reload Service | mongodb
+- name: service | mongodb | started
+  service:
+    name: mongod
+    state: started
+
+- name: service | mongodb | stopped
+  service:
+    name: mongod
+    state: stopped
+
+- name: service | mongodb | restarted
+  service:
+    name: mongod
+    state: restarted
+
+- name: service | mongodb | reloaded
   service:
     state: reloaded
     name: mongod
-  tags:
-    - disruptive

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,12 @@ dependencies:
   - role: telusdigital.apt-repository
     repository_key: "0x9ecbec467f0ceb10"
     repository_url: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
+  - role: telusdigital.fluentd
+    fluentd_config_name: mongod
+    fluentd_sources:
+      - path: '/data/log/mongod/mongod.log'
+        format: '^(?<date_time>(?<date>[^T]*)T(?<time>[^\+]*)\+(?<time_offset>\d{4})) \[(?<connection_thread>[^]]*)\] (?<message>.*)'
+        tag: mongodb.service
   - role: telusdigital.logrotate
     logrotate_name: mongod
 galaxy_info:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,12 +3,6 @@ dependencies:
   - role: telusdigital.apt-repository
     repository_key: "0x9ecbec467f0ceb10"
     repository_url: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
-  - role: telusdigital.fluentd
-    fluentd_config_name: mongod
-    fluentd_sources:
-      - path: '/data/log/mongod/mongod.log'
-        format: '^(?<date_time>(?<date>[^T]*)T(?<time>[^\+]*)\+(?<time_offset>\d{4})) \[(?<connection_thread>[^]]*)\] (?<message>.*)'
-        tag: mongodb.service
   - role: telusdigital.logrotate
     logrotate_name: mongod
 galaxy_info:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -29,7 +29,7 @@
     dest: /etc/mongod.conf
     regexp: '^#* *pidfilepath ?\='
     line: "pidfilepath = {{ mongodb_pidfile_path }}"
-  notify: Reload Service | mongodb
+  notify: service | mongodb | reloaded
   tags:
     - configuration
     - precise-configuration
@@ -44,7 +44,7 @@
     regexp: '^#* *auth ?\='
     line: 'auth = true'
   when: mongodb_auth_enabled
-  notify: Reload Service | mongodb
+  notify: service | mongodb | reloaded
   tags:
     - configuration
     - precise-configuration
@@ -56,7 +56,7 @@
     dest: /etc/mongod.conf
     regexp: '^#* *bind_ip'
   when: mongodb_accepts_external_connections
-  notify: Reload Service | mongodb
+  notify: service | mongodb | reloaded
   tags:
     - configuration
     - precise-configuration

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     state: directory
     path: "{{ mongodb_runtime_root }}"
     owner: "{{ mongodb_user }}"
-    group: wcadmin
+    group: "{{ mongodb_group }}"
     mode: 0775
   tags:
     - directory-structure
@@ -16,7 +16,7 @@
     state: directory
     path: /var/lib/mongodb
     owner: "{{ mongodb_user }}"
-    group: wcdevelop
+    group: "{{ mongodb_group }}"
     mode: 0755
   tags:
     - permissions

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -4,7 +4,7 @@
     state: directory
     path: "{{ mongodb_log_root }}"
     owner: "{{ mongodb_user }}"
-    group: wcdevelop
+    group: "{{ mongodb_group }}"
     mode: 0775
   tags:
     - directory-structure
@@ -16,7 +16,7 @@
     state: touch
     path: "{{ mongodb_log_path }}"
     owner: "{{ mongodb_user }}"
-    group: wcdevelop
+    group: "{{ mongodb_group }}"
     mode: 0664
   tags:
     - permissions

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -29,7 +29,7 @@
     dest: /etc/mongod.conf
     regexp: '^#* *logpath ?\='
     line: "logpath = {{ mongodb_log_path }}"
-  notify: Reload Service | mongodb
+  notify: service | mongodb | reloaded
   tags:
     - configuration
     - precise-configuration
@@ -42,7 +42,7 @@
     dest: /etc/mongod.conf
     regexp: '^#* *logappend ?\='
     line: 'logappend = true'
-  notify: Reload Service | mongodb
+  notify: service | mongodb | reloaded
   tags:
     - configuration
     - precise-configuration

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/inventory
+++ b/tests/inventory
@@ -4,3 +4,5 @@ localhost
 [local:vars]
 system_role=travis
 project=travis
+environment_tier=travis
+domain=travis

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,5 @@
+[local]
 localhost
+
+[local:vars]
+system_role=travis

--- a/tests/inventory
+++ b/tests/inventory
@@ -3,3 +3,4 @@ localhost
 
 [local:vars]
 system_role=travis
+project=travis

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - role: telusdigital.apt-repository
+      repository_key: "0x9ecbec467f0ceb10"
+      repository_url: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
+    - role: telusdigital.logrotate
+      logrotate_name: mongod
+    - role: ansible-mongodb
+      mongodb_client: yes
+      mongodb_server: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,12 @@
     - role: telusdigital.apt-repository
       repository_key: "0x9ecbec467f0ceb10"
       repository_url: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
+    - role: telusdigital.fluentd
+      fluentd_config_name: mongod
+      fluentd_sources:
+        - path: '/data/log/mongod/mongod.log'
+          format: '^(?<date_time>(?<date>[^T]*)T(?<time>[^\+]*)\+(?<time_offset>\d{4})) \[(?<connection_thread>[^]]*)\] (?<message>.*)'
+          tag: mongodb.service
     - role: telusdigital.logrotate
       logrotate_name: mongod
     - role: ansible-mongodb

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,3 +10,4 @@
     - role: ansible-mongodb
       mongodb_client: yes
       mongodb_server: yes
+


### PR DESCRIPTION
- Added tests
- Updated service handlers
- Updated file group

There was one project using the old mongodb service handler. I updated that project in the pull request here:
https://github.com/telusdigital/playbook-pc-migrate-voicemail/pull/3

Sorry about the pr with multiple updates. 